### PR TITLE
fix: logout과 login을 한다음 현재 url로 돌아오게하는 기능 구현

### DIFF
--- a/docrate/src/main/java/com/team/docrate/domain/review/controller/ReviewController.java
+++ b/docrate/src/main/java/com/team/docrate/domain/review/controller/ReviewController.java
@@ -1,5 +1,6 @@
 package com.team.docrate.domain.review.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.data.domain.Page;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -33,6 +34,7 @@ public class ReviewController {
             @PathVariable Long doctorId,
             @AuthenticationPrincipal String email,
             @RequestParam(value = "page", defaultValue = "1") int page,
+            HttpServletRequest request,
             Model model) {
 
         Doctor doctor = reviewService.getDoctorById(doctorId);
@@ -47,6 +49,7 @@ public class ReviewController {
         model.addAttribute("currentPage", page);
         model.addAttribute("totalPages", reviewPage.getTotalPages());
         model.addAttribute("averageRating", averageRating);
+        model.addAttribute("currentUrl", request.getRequestURI());
 
         if (email != null) {
             User loginUser = userService.findByEmail(email).orElse(null);

--- a/docrate/src/main/java/com/team/docrate/domain/user/controller/LogoutController.java
+++ b/docrate/src/main/java/com/team/docrate/domain/user/controller/LogoutController.java
@@ -20,11 +20,11 @@ public class LogoutController {
     @PostMapping("/logout")
     public String logout(
             HttpServletRequest request,
-            HttpServletResponse response
+            HttpServletResponse response,
+            @org.springframework.web.bind.annotation.RequestParam(value = "redirectUrl", required = false) String redirectUrl
     ) {
         String accessToken = resolveAccessToken(request);
         String refreshToken = resolveRefreshToken(request);
-
 
         userService.logout(accessToken, refreshToken);
 
@@ -33,6 +33,9 @@ public class LogoutController {
         deleteCookie(response, "accessToken");
         deleteCookie(response, "refreshToken");
 
+        if (StringUtils.hasText(redirectUrl) && redirectUrl.startsWith("/")) {
+            return "redirect:" + redirectUrl;
+        }
         return "redirect:/";
     }
 

--- a/docrate/src/main/java/com/team/docrate/domain/user/controller/UserController.java
+++ b/docrate/src/main/java/com/team/docrate/domain/user/controller/UserController.java
@@ -64,11 +64,14 @@ public class UserController {
     
     // GET /login → 로그인 페이지
     @GetMapping("/login")
-    public String loginForm(Model model) {
+    public String loginForm(
+            @org.springframework.web.bind.annotation.RequestParam(value = "redirectUrl", required = false) String redirectUrl,
+            Model model) {
     	// 로그인 폼과 바인딩할 DTO가 없으면 새로 생성
         if (!model.containsAttribute("loginRequestDto")) {
             model.addAttribute("loginRequestDto", new LoginRequestDto());
         }
+        model.addAttribute("redirectUrl", redirectUrl);
         // 로그인 페이지 반환
         return "users/login";
     }
@@ -78,16 +81,17 @@ public class UserController {
     public String login(
             @Valid LoginRequestDto loginRequestDto,
             BindingResult bindingResult,
+            @org.springframework.web.bind.annotation.RequestParam(value = "redirectUrl", required = false) String redirectUrl,
             HttpServletResponse response
     ) {
     	// 1. 입력한 검증 실패 시 로그인 페이지로 다시 이동
         if (bindingResult.hasErrors()) {
             return "users/login";
         }
-        
+
         // 2. 로그인 처리 (이메일/비밀번호 검증 + JWT
         LoginResponseDto loginResponse = userService.login(loginRequestDto);
-        
+
         int accessTokenCookieMaxAge = Math.toIntExact(accessTokenExpiration / 1000);
         int refreshTokenCookieMaxAge = Math.toIntExact(refreshTokenExpiration / 1000);
 
@@ -103,7 +107,10 @@ public class UserController {
                 refreshTokenCookieMaxAge
         ));
 
-        // 4. 로그인 성공 후 메인 페이지로 이동
+        // 4. 로그인 성공 후 redirectUrl이 있으면 해당 페이지로, 없으면 메인 페이지로 이동
+        if (org.springframework.util.StringUtils.hasText(redirectUrl) && redirectUrl.startsWith("/")) {
+            return "redirect:" + redirectUrl;
+        }
         return "redirect:/";
     }
 

--- a/docrate/src/main/java/com/team/docrate/global/security/SecurityConfig.java
+++ b/docrate/src/main/java/com/team/docrate/global/security/SecurityConfig.java
@@ -55,6 +55,11 @@ public class SecurityConfig {
                                 "/", "/signup", "/login", "/logout",
                                 "/css/**", "/js/**", "/images/**", "/favicon.ico"
                         ).permitAll()
+                        .requestMatchers(
+                                "/doctors",
+                                "/doctors/*",
+                                "/doctors/*/reviews"
+                            ).permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )

--- a/docrate/src/main/resources/templates/review/list.html
+++ b/docrate/src/main/resources/templates/review/list.html
@@ -16,7 +16,7 @@
 
             <div class="header-right">
                 <div th:if="${loginUser == null}" class="guest-menu">
-                    <a th:href="@{/login}" class="header-link">로그인</a>
+                    <a th:href="@{/login(redirectUrl=${currentUrl})}" class="header-link">로그인</a>
                     <a th:href="@{/signup}" class="header-btn">회원가입</a>
                 </div>
 
@@ -24,7 +24,7 @@
                     <span class="welcome-text" th:text="${loginUser.nickname} + '님'">사용자님</span>
                     <a th:href="@{/mypage}" class="header-link">마이페이지</a>
 
-                    <form th:action="@{/logout}" method="post" class="logout-form">
+                    <form th:action="@{/logout(redirectUrl=${currentUrl})}" method="post" class="logout-form">
                         <input type="hidden"
                                th:if="${_csrf != null}"
                                th:name="${_csrf.parameterName}"

--- a/docrate/src/main/resources/templates/users/login.html
+++ b/docrate/src/main/resources/templates/users/login.html
@@ -28,6 +28,7 @@
                            th:if="${_csrf != null}"
                            th:name="${_csrf.parameterName}"
                            th:value="${_csrf.token}" />
+                    <input type="hidden" name="redirectUrl" th:value="${redirectUrl}" />
 
                     <div class="form-group">
                         <label for="email" class="form-label">Email</label>


### PR DESCRIPTION
[로그인/로그아웃 후 현재 페이지 유지 사용법 안내]

  특정 페이지에서 로그인/로그아웃 후 그 페이지로 다시 돌아오게 하려면
  아래 두 가지만 추가하면 돼요.

  ---

  ① 해당 페이지 컨트롤러에 currentUrl 추가

  [전]
  public String yourMethod(
      @PathVariable Long id,
      Model model
  ) {
      ...
  }

  [후]
  import jakarta.servlet.http.HttpServletRequest; ← 추가

  public String yourMethod(
      @PathVariable Long id,
      HttpServletRequest request,  ← 추가
      Model model
  ) {
      ...
      model.addAttribute("currentUrl", request.getRequestURI());  ← 추가
      ...
  }

  ---

  ② HTML에서 로그인/로그아웃에 redirectUrl 넘기기

  로그인 링크
  [전]
  <a th:href="@{/login}">로그인</a>

  [후]
  <a th:href="@{/login(redirectUrl=${currentUrl})}">로그인</a>


  로그아웃 폼
  [전]
  <form th:action="@{/logout}" method="post">
      <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
      <button type="submit">로그아웃</button>
  </form>

  [후]
  <form th:action="@{/logout(redirectUrl=${currentUrl})}" method="post">
      <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
      <button type="submit">로그아웃</button>
  </form>

  ---

  참고
  - redirectUrl 없으면 기존대로 로그인/로그아웃 후 메인(/)으로 이동
  - currentUrl 추가가 필요 없는 페이지는 그냥 기존대로 두면 됨